### PR TITLE
Fix TimedEvent.wait - with ruby 1.9 wait does not return false on a timeout

### DIFF
--- a/lib/god/driver.rb
+++ b/lib/god/driver.rb
@@ -67,12 +67,11 @@ module God
       end
     end
 
-    def wait(timeout=nil)
+    def wait(timeout = nil)
       @monitor.synchronize do
-        unless @done
-          if timeout && !@done_condition.wait(timeout)
-            raise WaitTimeout
-          end
+        if !@done && timeout
+          @done_condition.wait(timeout)
+          @done or raise WaitTimeout
         end
       end
     end

--- a/test/test_driver.rb
+++ b/test/test_driver.rb
@@ -33,13 +33,13 @@ class TestDriver < Test::Unit::TestCase
       event.done
     end
 
-    event.wait(0.1)
+    event.wait(1)
   end
 
   def test_timeouts
     event = God::TimedEvent.new(0)
     event.wait(0.1)
-    flunk
+    flunk "Did not throw an exception"
   rescue WaitTimeout
     # Pass
   end


### PR DESCRIPTION
@christopherdeutsch  - Can you take a quick look.  With ruby 1.8, a condition wait would return false if it the condition was not signaled in the timeout.  This changed in 1.9.   But I like the new code better anyway.  

The only other change is to address a minor race condition and to add more information to the failure. 

Let me know if you have any questions. 