### PR TITLE
add build script and vendored gems

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ bbin/
 site/index.html
 gh-pages
 .idea/
+vendor/

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+#
+# this script will build a tarball suitable for
+# installation in a packer image without real
+# git credentials or reliable access to private
+# git repos
+#
+# assumes that the god repo is downloaded with a
+# built package from virtualbox
+#
+filename="god-`date +%s`.tar.gz"
+
+bundle package
+pushd ..
+tar czvf $filename god
+popd
+
+echo "created ../$filename"
+echo `shasum -a256 ../$filename`


### PR DESCRIPTION
This allows us to upload a tarball containing all the bundled gems, for easier installation on packer images.