### PR TITLE
Add Backstage catalog-info.yaml

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,17 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: god
+  title: god
+  description: "Ruby process monitor"
+  tags:
+    - ruby
+  annotations:
+    backstage.io/source-location: url:https://github.com/Invoca/god/
+    github.com/project-slug: Invoca/god
+    buildkite.com/project-slug: invoca/god
+spec:
+  type: service
+  lifecycle: production
+  owner: TODO-add-owner
+  # system: TODO — see https://github.com/Invoca/backstage-catalog


### PR DESCRIPTION
## Add Backstage `catalog-info.yaml`

Registers this repo in the [Invoca Backstage catalog](https://backstage.invoca.net).

### What was auto-generated
- **type**: `service` (inferred from repo name/language)
- **owner**: **⚠ unknown — please set before merging**
- **system**: **⚠ not set — please add before merging**

### Please review before merging
- [ ] `spec.owner` is correct
- [ ] `spec.system` is set (see [taxonomy](https://github.com/Invoca/backstage-catalog))
- [ ] `metadata.description` is accurate
- [ ] Add `dependsOn`, `providesApis`, or `consumesApis` if relevant

See [voice-agent](https://github.com/Invoca/voice-agent/tree/main/.backstage) for a fully-built example.

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)
